### PR TITLE
Scale up 4 x

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -39,7 +39,7 @@ using namespace svg;
 int main()
 {
     Size size(100, 100);
-    Document doc("my_svg.svg", Layout(size, Layout::BottomLeft));
+    Document doc("my_svg.svg", Layout(size));
 
     // Red image border.
     Polygon border(Stroke(1, Color::Red));

--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,7 @@ using namespace svg;
 
 int main()
 {
-    Size size(100, 100);
+    Size size(500, 500);
     Document doc("my_svg.svg", Layout(size));
 
     // Red image border.
@@ -53,37 +53,37 @@ int main()
     Polyline polyline_a(Stroke(.5, Color::Blue));
     Polyline polyline_b(Stroke(.5, Color::Aqua));
     Polyline polyline_c(Stroke(.5, Color::Fuchsia));
-    polyline_a << Point(0, 0) << Point(10, 30) << Point(20, 40) << Point(30, 45)
-               << Point(40, 44);
-    polyline_b << Point(0, 10) << Point(10, 22) << Point(20, 30)
-               << Point(30, 32) << Point(40, 30);
-    polyline_c << Point(0, 12) << Point(10, 15) << Point(20, 14)
-               << Point(30, 10) << Point(40, 2);
+    polyline_a << Point(0, 0) << Point(40, 120) << Point(80, 160)
+               << Point(120, 180) << Point(160, 176);
+    polyline_b << Point(0, 40) << Point(40, 88) << Point(80, 120)
+               << Point(120, 128) << Point(160, 120);
+    polyline_c << Point(0, 48) << Point(40, 60) << Point(80, 56)
+               << Point(120, 40) << Point(160, 8);
     chart << polyline_a << polyline_b << polyline_c;
     doc << chart;
 
     // Condensed notation, parenthesis isolate temporaries that are inserted
     // into parents.
-    doc << (LineChart(Size(65, 5))
+    doc << (LineChart(Size(260, 20))
             << (Polyline(Stroke(.5, Color::Blue))
-                << Point(0, 0) << Point(10, 8) << Point(20, 13))
+                << Point(0, 0) << Point(40, 32) << Point(80, 52))
             << (Polyline(Stroke(.5, Color::Orange))
-                << Point(0, 10) << Point(10, 16) << Point(20, 20))
+                << Point(0, 40) << Point(40, 64) << Point(80, 80))
             << (Polyline(Stroke(.5, Color::Cyan))
-                << Point(0, 5) << Point(10, 13) << Point(20, 16)));
+                << Point(0, 20) << Point(40, 52) << Point(80, 64)));
 
-    doc << Circle(Point(80, 80), 20, Fill(Color(100, 200, 120)),
+    doc << Circle(Point(320, 320), 80, Fill(Color(100, 200, 120)),
                   Stroke(1, Color(200, 250, 150)));
 
-    doc << Text(Point(5, 77), "Simple SVG", Fill(Color::Silver),
-                Font(10, "Verdana"));
+    doc << Text(Point(20, 300), "Simple SVG", Fill(Color::Silver),
+                Font(40, "Verdana"));
 
     doc << (Polygon(Fill(Color(200, 160, 220)),
                     Stroke(.5, Color(150, 160, 200)))
-            << Point(20, 70) << Point(25, 72) << Point(33, 70) << Point(35, 60)
-            << Point(25, 55) << Point(18, 63));
+            << Point(80, 280) << Point(100, 288) << Point(132, 280)
+            << Point(140, 240) << Point(100, 220) << Point(72, 252));
 
-    doc << Rectangle(Point(70, 55), 20, 15, Fill(Color::Yellow));
+    doc << Rectangle(Point(280, 220), 80, 60, Fill(Color::Yellow));
 
     if (doc.save())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -38,19 +38,18 @@ using namespace svg;
 
 int main()
 {
-    Dimensions dimensions(100, 100);
-    Document doc("my_svg.svg", Layout(dimensions, Layout::BottomLeft));
+    Size size(100, 100);
+    Document doc("my_svg.svg", Layout(size, Layout::BottomLeft));
 
     // Red image border.
     Polygon border(Stroke(1, Color::Red));
-    border << Point(0, 0) << Point(dimensions.width, 0)
-           << Point(dimensions.width, dimensions.height)
-           << Point(0, dimensions.height);
+    border << Point(0, 0) << Point(size.width, 0)
+           << Point(size.width, size.height) << Point(0, size.height);
     doc << border;
 
     // Long notation.  Local variable is created, children are added to
     // varaible.
-    LineChart chart(Dimensions(), 5.0);
+    LineChart chart(Size(), 5.0);
     Polyline polyline_a(Stroke(.5, Color::Blue));
     Polyline polyline_b(Stroke(.5, Color::Aqua));
     Polyline polyline_c(Stroke(.5, Color::Fuchsia));
@@ -65,7 +64,7 @@ int main()
 
     // Condensed notation, parenthesis isolate temporaries that are inserted
     // into parents.
-    doc << (LineChart(Dimensions(65, 5))
+    doc << (LineChart(Size(65, 5))
             << (Polyline(Stroke(.5, Color::Blue))
                 << Point(0, 0) << Point(10, 8) << Point(20, 13))
             << (Polyline(Stroke(.5, Color::Orange))

--- a/src/simpler_svg.hpp
+++ b/src/simpler_svg.hpp
@@ -61,12 +61,10 @@ std::string elemEnd(std::string const &element_name)
 }
 std::string emptyElemEnd() { return "/>\n"; }
 
-struct Dimensions
+struct Size
 {
-    Dimensions(double width, double height) : width(width), height(height) {}
-    explicit Dimensions(double combined = 0) : width(combined), height(combined)
-    {
-    }
+    Size(double width, double height) : width(width), height(height) {}
+    explicit Size(double combined = 0) : width(combined), height(combined) {}
     double width;
     double height;
 };
@@ -113,7 +111,7 @@ struct Layout
         BottomRight
     };
 
-    explicit Layout(Dimensions const &dimensions = Dimensions(400, 300),
+    explicit Layout(Size const &dimensions = Size(400, 300),
                     Origin origin = BottomLeft, double scale = 1,
                     Point const &origin_offset = Point(0, 0))
         : dimensions(dimensions),
@@ -122,7 +120,7 @@ struct Layout
           origin_offset(origin_offset)
     {
     }
-    Dimensions dimensions;
+    Size dimensions;
     double scale;
     Origin origin;
     Point origin_offset;
@@ -612,7 +610,7 @@ class Text : public Shape
 class LineChart : public Shape
 {
    public:
-    explicit LineChart(Dimensions margin = Dimensions(), double scale = 1,
+    explicit LineChart(Size margin = Size(), double scale = 1,
                        Stroke const &axis_stroke = Stroke(.5, Color::Purple))
         : axis_stroke(axis_stroke), margin(margin), scale(scale)
     {
@@ -642,11 +640,11 @@ class LineChart : public Shape
 
    private:
     Stroke axis_stroke;
-    Dimensions margin;
+    Size margin;
     double scale;
     std::vector<Polyline> polylines;
 
-    std::optional<Dimensions> getDimensions() const
+    std::optional<Size> getSize() const
     {
         if (polylines.empty()) return std::nullopt;
 
@@ -664,11 +662,11 @@ class LineChart : public Shape
                 max->y = getMaxPoint(polylines[i].points)->y;
         }
 
-        return Dimensions(max->x - min->x, max->y - min->y);
+        return Size(max->x - min->x, max->y - min->y);
     }
     std::string axisString(Layout const &layout) const
     {
-        std::optional<Dimensions> dimensions = getDimensions();
+        std::optional<Size> dimensions = getSize();
         if (!dimensions) return "";
 
         // Make the axis 10% wider and higher than the data points.
@@ -692,7 +690,7 @@ class LineChart : public Shape
         std::vector<Circle> vertices;
         for (unsigned i = 0; i < shifted_polyline.points.size(); ++i)
             vertices.push_back(Circle(shifted_polyline.points[i],
-                                      getDimensions()->height / 30.0,
+                                      getSize()->height / 30.0,
                                       Fill(Color::Black)));
 
         return shifted_polyline.toString(layout) +

--- a/src/simpler_svg.hpp
+++ b/src/simpler_svg.hpp
@@ -103,48 +103,26 @@ std::optional<Point> getMaxPoint(std::vector<Point> const &points)
 // Defines the dimensions, scale, origin, and origin offset of the document.
 struct Layout
 {
-    enum Origin
-    {
-        TopLeft,
-        BottomLeft,
-        TopRight,
-        BottomRight
-    };
-
-    explicit Layout(Size const &dimensions = Size(400, 300),
-                    Origin origin = BottomLeft, double scale = 1,
+    explicit Layout(Size const &dimensions = Size(400, 300), double scale = 1,
                     Point const &origin_offset = Point(0, 0))
-        : dimensions(dimensions),
-          scale(scale),
-          origin(origin),
-          origin_offset(origin_offset)
+        : dimensions(dimensions), scale(scale), origin_offset(origin_offset)
     {
     }
     Size dimensions;
     double scale;
-    Origin origin;
     Point origin_offset;
 };
 
 // Convert coordinates in user space to SVG native space.
 double translateX(double x, Layout const &layout)
 {
-    if (layout.origin == Layout::BottomRight ||
-        layout.origin == Layout::TopRight)
-        return layout.dimensions.width -
-               ((x + layout.origin_offset.x) * layout.scale);
-    else
-        return (layout.origin_offset.x + x) * layout.scale;
+    return (layout.origin_offset.x + x) * layout.scale;
 }
 
 double translateY(double y, Layout const &layout)
 {
-    if (layout.origin == Layout::BottomLeft ||
-        layout.origin == Layout::BottomRight)
-        return layout.dimensions.height -
-               ((y + layout.origin_offset.y) * layout.scale);
-    else
-        return (layout.origin_offset.y + y) * layout.scale;
+    return layout.dimensions.height -
+           ((y + layout.origin_offset.y) * layout.scale);
 }
 double translateScale(double dimension, Layout const &layout)
 {

--- a/tests/simpler_svg_test.cpp
+++ b/tests/simpler_svg_test.cpp
@@ -7,8 +7,7 @@ using namespace svg;
 // Test the Color class
 TEST(ColorTest, Constructor)
 {
-    Layout layout = Layout(Size(100, 100),
-                           Layout::BottomLeft);  // default is BottomLeft
+    Layout layout = Layout(Size(100, 100));
     Color c(100, 150, 200);
     EXPECT_EQ(c.toString(layout), "rgb(100,150,200)");
 }
@@ -33,10 +32,9 @@ TEST(SizeTest, Constructor)
 TEST(LayoutTest, Constructor)
 {
     Size d(100, 100);
-    Layout l(d, Layout::BottomLeft);
+    Layout l(d);
     EXPECT_EQ(l.dimensions.width, 100);
     EXPECT_EQ(l.dimensions.height, 100);
-    EXPECT_EQ(l.origin, Layout::BottomLeft);
 }
 
 // Test the Circle class
@@ -44,7 +42,7 @@ TEST(CircleTest, Constructor)
 {
     Point center(50, 50);
     Circle c(center, 30, Fill(Color::Red), Stroke(2, Color::Blue));
-    Layout l(Size(100, 100), Layout::BottomLeft);
+    Layout l(Size(100, 100));
     std::string expected =
         "\t<circle cx=\"50\" cy=\"50\" r=\"15\" fill=\"rgb(255,0,0)\" "
         "stroke-width=\"2\" stroke=\"rgb(0,0,255)\" />\n";
@@ -56,7 +54,7 @@ TEST(ElipseTest, Constructor)
 {
     Point center(50, 50);
     Elipse e(center, 30, 40, Fill(Color::Red), Stroke(2, Color::Blue));
-    Layout l(Size(100, 100), Layout::BottomLeft);
+    Layout l(Size(100, 100));
     std::string expected =
         "\t<ellipse cx=\"50\" cy=\"50\" rx=\"15\" ry=\"20\" "
         "fill=\"rgb(255,0,0)\" "
@@ -69,9 +67,9 @@ TEST(RectangleTest, Constructor)
 {
     Point origin(10, 20);
     Rectangle r(origin, 50, 30, Fill(Color::Green));
-    Layout l(Size(100, 100), Layout::TopLeft);
+    Layout l(Size(100, 100));
     std::string expected =
-        "\t<rect x=\"10\" y=\"20\" width=\"50\" height=\"30\" "
+        "\t<rect x=\"10\" y=\"80\" width=\"50\" height=\"30\" "
         "fill=\"rgb(0,128,0)\" />\n";
     EXPECT_EQ(r.toString(l), expected);
 }
@@ -82,7 +80,7 @@ TEST(LineTest, Constructor)
     Point start(0, 0);
     Point end(100, 100);
     Line line(start, end, Stroke(2, Color::Black));
-    Layout l(Size(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200));
     std::string expected =
         "\t<line x1=\"0\" y1=\"200\" x2=\"100\" y2=\"100\" stroke-width=\"2\" "
         "stroke=\"rgb(0,0,0)\" />\n";
@@ -97,7 +95,7 @@ TEST(PolygonTest, Constructor)
     polygon << Point(100, 0);
     polygon << Point(100, 100);
     polygon << Point(0, 100);
-    Layout l(Size(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200));
     std::string expected =
         "\t<polygon points=\"0,200 100,200 100,100 0,100 \" "
         "fill=\"transparent\" />\n";
@@ -112,7 +110,7 @@ TEST(PolylineTest, Constructor)
     polyline << Point(100, 0);
     polyline << Point(100, 100);
     polyline << Point(0, 100);
-    Layout l(Size(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200));
     std::string expected =
         "\t<polyline points=\"0,200 100,200 100,100 0,100 \" "
         "fill=\"transparent\" />\n";
@@ -124,9 +122,9 @@ TEST(TextTest, Constructor)
 {
     Point pos(10, 20);
     Text text(pos, "Hello, SVG!", Fill(Color::Blue), Font(12, "Arial"));
-    Layout l(Size(100, 100), Layout::TopLeft);
+    Layout l(Size(100, 100));
     std::string expected =
-        "\t<text x=\"10\" y=\"20\" fill=\"rgb(0,0,255)\" font-size=\"12\" "
+        "\t<text x=\"10\" y=\"80\" fill=\"rgb(0,0,255)\" font-size=\"12\" "
         "font-family=\"Arial\" >Hello, SVG!</text>\n";
     EXPECT_EQ(text.toString(l), expected);
 }
@@ -140,7 +138,7 @@ TEST(LineChartTest, Constructor)
              << Point(300, 300) << Point(400, 400) << Point(500, 500);
     chart << polyline;
 
-    Layout l(Size(600, 600), Layout::BottomLeft);
+    Layout l(Size(600, 600));
     std::string expected =
         "\t<polyline points=\"0,600 100,500 200,400 300,300 400,200 500,100 \" "
         "fill=\"transparent\" />\n\t<circle cx=\"0\" cy=\"600\" r=\"8.33333\" "
@@ -159,7 +157,7 @@ TEST(LineChartTest, Constructor)
 TEST(DocumentTest, SaveAndLoad)
 {
     Size dimensions(100, 100);
-    Document doc("test.svg", Layout(dimensions, Layout::BottomLeft));
+    Document doc("test.svg", Layout(dimensions));
 
     doc << Circle(Point(50, 50), 30, Fill(Color::Red));
 

--- a/tests/simpler_svg_test.cpp
+++ b/tests/simpler_svg_test.cpp
@@ -7,7 +7,7 @@ using namespace svg;
 // Test the Color class
 TEST(ColorTest, Constructor)
 {
-    Layout layout = Layout(Dimensions(100, 100),
+    Layout layout = Layout(Size(100, 100),
                            Layout::BottomLeft);  // default is BottomLeft
     Color c(100, 150, 200);
     EXPECT_EQ(c.toString(layout), "rgb(100,150,200)");
@@ -21,10 +21,10 @@ TEST(PointTest, Constructor)
     EXPECT_EQ(p.y, 20);
 }
 
-// Test the Dimensions class
-TEST(DimensionsTest, Constructor)
+// Test the Size class
+TEST(SizeTest, Constructor)
 {
-    Dimensions d(100, 200);
+    Size d(100, 200);
     EXPECT_EQ(d.width, 100);
     EXPECT_EQ(d.height, 200);
 }
@@ -32,7 +32,7 @@ TEST(DimensionsTest, Constructor)
 // Test the Layout class
 TEST(LayoutTest, Constructor)
 {
-    Dimensions d(100, 100);
+    Size d(100, 100);
     Layout l(d, Layout::BottomLeft);
     EXPECT_EQ(l.dimensions.width, 100);
     EXPECT_EQ(l.dimensions.height, 100);
@@ -44,7 +44,7 @@ TEST(CircleTest, Constructor)
 {
     Point center(50, 50);
     Circle c(center, 30, Fill(Color::Red), Stroke(2, Color::Blue));
-    Layout l(Dimensions(100, 100), Layout::BottomLeft);
+    Layout l(Size(100, 100), Layout::BottomLeft);
     std::string expected =
         "\t<circle cx=\"50\" cy=\"50\" r=\"15\" fill=\"rgb(255,0,0)\" "
         "stroke-width=\"2\" stroke=\"rgb(0,0,255)\" />\n";
@@ -56,7 +56,7 @@ TEST(ElipseTest, Constructor)
 {
     Point center(50, 50);
     Elipse e(center, 30, 40, Fill(Color::Red), Stroke(2, Color::Blue));
-    Layout l(Dimensions(100, 100), Layout::BottomLeft);
+    Layout l(Size(100, 100), Layout::BottomLeft);
     std::string expected =
         "\t<ellipse cx=\"50\" cy=\"50\" rx=\"15\" ry=\"20\" "
         "fill=\"rgb(255,0,0)\" "
@@ -69,7 +69,7 @@ TEST(RectangleTest, Constructor)
 {
     Point origin(10, 20);
     Rectangle r(origin, 50, 30, Fill(Color::Green));
-    Layout l(Dimensions(100, 100), Layout::TopLeft);
+    Layout l(Size(100, 100), Layout::TopLeft);
     std::string expected =
         "\t<rect x=\"10\" y=\"20\" width=\"50\" height=\"30\" "
         "fill=\"rgb(0,128,0)\" />\n";
@@ -82,7 +82,7 @@ TEST(LineTest, Constructor)
     Point start(0, 0);
     Point end(100, 100);
     Line line(start, end, Stroke(2, Color::Black));
-    Layout l(Dimensions(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200), Layout::BottomLeft);
     std::string expected =
         "\t<line x1=\"0\" y1=\"200\" x2=\"100\" y2=\"100\" stroke-width=\"2\" "
         "stroke=\"rgb(0,0,0)\" />\n";
@@ -97,7 +97,7 @@ TEST(PolygonTest, Constructor)
     polygon << Point(100, 0);
     polygon << Point(100, 100);
     polygon << Point(0, 100);
-    Layout l(Dimensions(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200), Layout::BottomLeft);
     std::string expected =
         "\t<polygon points=\"0,200 100,200 100,100 0,100 \" "
         "fill=\"transparent\" />\n";
@@ -112,7 +112,7 @@ TEST(PolylineTest, Constructor)
     polyline << Point(100, 0);
     polyline << Point(100, 100);
     polyline << Point(0, 100);
-    Layout l(Dimensions(200, 200), Layout::BottomLeft);
+    Layout l(Size(200, 200), Layout::BottomLeft);
     std::string expected =
         "\t<polyline points=\"0,200 100,200 100,100 0,100 \" "
         "fill=\"transparent\" />\n";
@@ -124,7 +124,7 @@ TEST(TextTest, Constructor)
 {
     Point pos(10, 20);
     Text text(pos, "Hello, SVG!", Fill(Color::Blue), Font(12, "Arial"));
-    Layout l(Dimensions(100, 100), Layout::TopLeft);
+    Layout l(Size(100, 100), Layout::TopLeft);
     std::string expected =
         "\t<text x=\"10\" y=\"20\" fill=\"rgb(0,0,255)\" font-size=\"12\" "
         "font-family=\"Arial\" >Hello, SVG!</text>\n";
@@ -140,7 +140,7 @@ TEST(LineChartTest, Constructor)
              << Point(300, 300) << Point(400, 400) << Point(500, 500);
     chart << polyline;
 
-    Layout l(Dimensions(600, 600), Layout::BottomLeft);
+    Layout l(Size(600, 600), Layout::BottomLeft);
     std::string expected =
         "\t<polyline points=\"0,600 100,500 200,400 300,300 400,200 500,100 \" "
         "fill=\"transparent\" />\n\t<circle cx=\"0\" cy=\"600\" r=\"8.33333\" "
@@ -158,7 +158,7 @@ TEST(LineChartTest, Constructor)
 // Test the Document class
 TEST(DocumentTest, SaveAndLoad)
 {
-    Dimensions dimensions(100, 100);
+    Size dimensions(100, 100);
     Document doc("test.svg", Layout(dimensions, Layout::BottomLeft));
 
     doc << Circle(Point(50, 50), 30, Fill(Color::Red));


### PR DESCRIPTION
- `main` demo: scale up 4 x
- remove `enum Layout::Origin,` use former `BottomLeft`
- rename `class Dimensions` -> `class Size`
- remove `class optional`, use `std::optional`