### PR TITLE
add clone() to each Shape class

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -89,9 +89,8 @@ int main()
     doc << Rectangle(Point(280, 220), 80, 60, Fill(Color::Yellow));
 
     Group g("G1");
-    g.addShape(std::make_unique<Circle>(Point(0, 0), 30, Fill(Color::Red)));
-    g.addShape(std::make_unique<Rectangle>(Point(0, 0), 30, 15, Fill(),
-                                           Stroke(1, Color::Black)));
+    g << Circle(Point(0, 0), 30, Fill(Color::Red));
+    g << Rectangle(Point(0, 0), 30, 15, Fill(), Stroke(1, Color::Black));
     doc << g;
 
     g.offset(Point(400, 15));

--- a/tests/simpler_svg_test.cpp
+++ b/tests/simpler_svg_test.cpp
@@ -233,13 +233,11 @@ TEST(GroupTest, Constructor)
 {
     Group group;
 
-    // Create a Rectangle
-    Rectangle rect(Point(100, 100), 200, 150, Fill(Color::Blue));
-    group.addShape(std::make_unique<Rectangle>(rect));
+    // Add a Rectangle to the group
+    group << Rectangle(Point(100, 100), 200, 150, Fill(Color::Blue));
 
-    // Create a Circle
-    Circle circle(Point(300, 200), 50, Fill(Color::Red));
-    group.addShape(std::make_unique<Circle>(circle));
+    // Add a Circle to the group
+    group << Circle(Point(300, 200), 50, Fill(Color::Red));
 
     Layout l(Size(600, 600));
     std::string expected =


### PR DESCRIPTION
- add `clone()` to each `Shape` class
- add `Group::operator<<`, remove `Group:addShape`
- add `Group(const Group &other)` copy-constructor